### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 fontdump
 ========
 [![Build Status](https://travis-ci.org/glasslion/fontdump.svg?branch=master)](https://travis-ci.org/glasslion/fontdump)
-[![Latest Version](https://pypip.in/version/fontdump/badge.svg)](https://pypi.python.org/pypi/fontdump/)
-[![License](https://pypip.in/license/fontdump/badge.svg)](https://pypi.python.org/pypi/fontdump/)
+[![Latest Version](https://img.shields.io/pypi/v/fontdump.svg)](https://pypi.python.org/pypi/fontdump/)
+[![License](https://img.shields.io/pypi/l/fontdump.svg)](https://pypi.python.org/pypi/fontdump/)
 
 
 A command line tool to dump the CSS and different formats of fonts for [Google Fonts][1], so you can serve them on your local servers.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fontdump))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fontdump`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.